### PR TITLE
Fix IndexOutOfBoundsException in Family branch accessors for families without a stripped branch

### DIFF
--- a/common/src/main/java/com/dtteam/dynamictrees/tree/family/Family.java
+++ b/common/src/main/java/com/dtteam/dynamictrees/tree/family/Family.java
@@ -311,9 +311,11 @@ public class Family extends RegistryEntry<Family> implements Resettable<Family> 
     }
 
     protected Optional<BranchBlock> getBranchBlock(int index) {
+        if (index < 0 || index >= branches.size()) return Optional.empty(); // Some families (e.g. from add-on tree packs) have no stripped branch entry.
         return Optionals.ofBlock(branches.get(index).getBlock());
     }
     protected Optional<Item> getBranchItem(int index) {
+        if (index < 0 || index >= branches.size()) return Optional.empty();
         return branches.get(index).getItem();
     }
 


### PR DESCRIPTION
### Problem

`Family.getBranchBlock(int)` and `Family.getBranchItem(int)` index directly into the `branches` list. Any family that has no stripped branch entry (only `BRANCH_INDEX` populated) throws when `getStrippedBranch()` is called:

```
java.lang.IndexOutOfBoundsException: Index 1 out of bounds for length 1
  at com.dtteam.dynamictrees.tree.family.Family.getBranchBlock(Family.java)
  at com.dtteam.dynamictrees.tree.family.Family.getStrippedBranch(Family.java)
  ... (client model handling code iterating families/branch blocks)
```

This is easy to hit in practice: several add-on tree pack families (e.g. from dtbop / dtterralith) register families without stripped branches, and any client-side code that walks families and asks for the stripped branch (model handling does) crashes repeatedly during model bake.

### Fix

Bounds-check the index in the two protected accessors and return `Optional.empty()`, which is what their `Optional` return type already promises: "no such branch". No signature changes; callers that use `ifPresent`/`map` now behave correctly for families lacking a stripped branch.

Found while running a Fabric build in a full production instance with add-on tree packs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
