### PR TITLE
Fabric: register blocks/items eagerly and implement registerEntityDataSerializer via FabricEntityDataRegistry

### DIFF
--- a/fabric/src/main/java/com/dtteam/dynamictrees/registry/FabricRegistryLoader.java
+++ b/fabric/src/main/java/com/dtteam/dynamictrees/registry/FabricRegistryLoader.java
@@ -51,13 +51,15 @@ public class FabricRegistryLoader extends RegistryLoader {
     @Override
     public <T extends Block> Supplier<T> registerBlock(String name, Function<Identifier, T> newBlock) {
         Identifier id = DynamicTrees.location(name);
-        return ()-> Registry.register(BuiltInRegistries.BLOCK, id, newBlock.apply(id));
+        T block = Registry.register(BuiltInRegistries.BLOCK, id, newBlock.apply(id));
+        return ()-> block;
     }
 
     @Override
     public <T extends Item> Supplier<T> registerItem(String name, Function<Identifier, T> newBlock) {
         Identifier id = DynamicTrees.location(name);
-        return ()-> Registry.register(BuiltInRegistries.ITEM, id, newBlock.apply(id));
+        T item = Registry.register(BuiltInRegistries.ITEM, id, newBlock.apply(id));
+        return ()-> item;
     }
 
     @Override

--- a/fabric/src/main/java/com/dtteam/dynamictrees/registry/FabricRegistryLoader.java
+++ b/fabric/src/main/java/com/dtteam/dynamictrees/registry/FabricRegistryLoader.java
@@ -5,12 +5,14 @@ import com.dtteam.dynamictrees.recipe.DendroPotionRecipeHandler;
 import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.serialization.MapCodec;
 import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup;
+import net.fabricmc.fabric.api.object.builder.v1.entity.FabricEntityDataRegistry;
 import net.minecraft.commands.synchronization.ArgumentTypeInfo;
 import net.minecraft.commands.synchronization.ArgumentTypeInfos;
 import net.minecraft.core.Registry;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.syncher.EntityDataSerializer;
 import net.minecraft.resources.Identifier;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.Entity;
@@ -100,6 +102,15 @@ public class FabricRegistryLoader extends RegistryLoader {
     public <T> Supplier<DataComponentType<T>> registerDataComponentType(String name, UnaryOperator<DataComponentType.Builder<T>> operator) {
         DataComponentType<T> type = Registry.register(BuiltInRegistries.DATA_COMPONENT_TYPE, DynamicTrees.location(name), operator.apply(DataComponentType.builder()).build());
         return ()-> type;
+    }
+
+    @Override
+    public <T> Supplier<EntityDataSerializer<T>> registerEntityDataSerializer(String name, Supplier<EntityDataSerializer<T>> operator) {
+        EntityDataSerializer<T> serializer = operator.get();
+        // Fabric API forbids vanilla's EntityDataSerializers.registerSerializer at runtime
+        // ("use FabricEntityDataRegistry.register instead"), so register through its API.
+        FabricEntityDataRegistry.register(DynamicTrees.location(name), serializer);
+        return ()-> serializer;
     }
 
     @Override


### PR DESCRIPTION
Two Fabric registration bugs found while porting and running the Fabric build in a full (~90 mod) production client instance.

### 1. `registerBlock` / `registerItem` register lazily, so some entries never register

`FabricRegistryLoader.registerBlock`/`registerItem` return `() -> Registry.register(...)` — registration only happens when somebody first polls the supplier. Consequences observed at runtime:

- Entries nobody polls during init (e.g. `DTRegistries.DIRT_BUCKET`) never make it into the registry at all — the dirt bucket crafting recipe then fails to load with `Unknown registry key ... dynamictrees:dirt_bucket`.
- A first poll after init would hit a frozen registry and throw.
- Polling the supplier twice would attempt a double registration.

Fixed by registering eagerly at call time and returning the captured instance, matching the other `register*` methods in the same class.

### 2. Missing `registerEntityDataSerializer` implementation — must go through `FabricEntityDataRegistry`

`RegistryLoader` declares `registerEntityDataSerializer` as abstract and the NeoForge loader implements it, but `FabricRegistryLoader` is missing the override entirely. Implementing it via vanilla's `EntityDataSerializers.registerSerializer` (the obvious route, and what we tried first) is rejected by Fabric API at runtime:

```
java.lang.IllegalStateException: Tried to register entity data serializer ... using EntityDataSerializers.registerSerializer.
This is not allowed as it can lead to desynchronization issues; use FabricEntityDataRegistry.register instead.
```

which fires on the first tree pack load (`Species.generateSeed` → `Seed.<init>`) and takes down the whole mod init. This PR implements the override through `FabricEntityDataRegistry.register(DynamicTrees.location(name), serializer)`.

### Compile status (full transparency)

`:fabric:compileJava` on `develop/26.1.2` currently fails at baseline with ~587 pre-existing errors (the module looks mid-port against the 26.1 toolchain — old `renderer.v1` model API, Jade/Continuity compat, loot type classes, etc.). I verified with `-Xmaxerrs` raised that the error set is unchanged by this patch and that none of the reported errors involve the lines added or modified here; both fixes are the exact change we run (and have validated at runtime) in our ported Fabric build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
