### PR TITLE
Fix ConcurrentModificationException [1.21.1]

### DIFF
--- a/common/src/main/java/com/dtteam/dynamictrees/api/registry/AbstractRegistry.java
+++ b/common/src/main/java/com/dtteam/dynamictrees/api/registry/AbstractRegistry.java
@@ -188,9 +188,14 @@ public abstract class AbstractRegistry<V extends RegistryEntry<V>> implements Re
         this.locked = true;
         this.dump();
 
-        // Run all of the on lock runnables and then clear them.
-        this.onLockRunnables.forEach(Runnable::run);
-        this.onLockRunnables.clear();
+        if (onLockRunnables.isEmpty()) {
+            return;
+        }
+
+        // Copy the onLockRunnables to prevent a ConcurrentModificationException
+        List<Runnable> current = new ArrayList<>(onLockRunnables);
+        onLockRunnables.clear();
+        current.forEach(Runnable::run);
     }
 
     /**


### PR DESCRIPTION
If an on lock runnable runs `runOnNextLock()`, it would throw a `ConcurrentModificationException`.
Now, it just adds a runnable that will run on the next `lock()`.