### PR TITLE
Fix falling tree invisible on shader  (mc 26.1.2)

### DIFF
--- a/common/src/main/java/com/dtteam/dynamictrees/model/entity/FallingTreeEntityModel.java
+++ b/common/src/main/java/com/dtteam/dynamictrees/model/entity/FallingTreeEntityModel.java
@@ -22,6 +22,7 @@ import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
 import net.minecraft.client.resources.model.geometry.BakedQuad;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.util.ARGB;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
@@ -157,7 +158,7 @@ public class FallingTreeEntityModel extends EntityModel<FallingTreeRenderState> 
                 g *= diffuse;
                 b *= diffuse;
             }
-            int newColor = ((int)(r * 255F) & 255) << 16 | ((int)(g * 255F) & 255) << 8 | ((int)(b * 255F) & 255);
+            int newColor = ARGB.colorFromFloat(1.0F, r, g, b);
             QuadInstance instance = new QuadInstance();
             instance.setColor(newColor);
             instance.setLightCoords(packedLight);


### PR DESCRIPTION
I was using Dynamic Trees BETA4(26.1.2) on my server and notice that on using shader, the falling tree become invisible and only the shadow is the thing rendered on the shader side 

so i have fixed the RGB calc to minecraft's ARGB util to preserve opacity and made the falling tree compatible with shaders 
